### PR TITLE
Cannot import as es6 module

### DIFF
--- a/money.js
+++ b/money.js
@@ -163,4 +163,4 @@
 	}
 
 	// Root will be `window` in browser or `global` on the server:
-}(this));
+}(typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
`this` is undefined when imported as es6 module.

Include detection from umd: https://github.com/umdjs/umd/blob/master/templates/amdWeb.js